### PR TITLE
Update GitLab URLs to SHIP 2.0

### DIFF
--- a/products-details/container-stack.json
+++ b/products-details/container-stack.json
@@ -18,7 +18,7 @@
   "apps": [
     {
       "name": "GitLab - Repository & CI",
-      "url": "https://gitlab-in.ship.gov.sg/"
+      "url": "https://sgts.gitlab-dedicated.com/wog/gvt/cstack/groups/tenants/"
     },
     {
       "name": "Argo CD (Development)",


### PR DESCRIPTION
CSTACK has completed repository migrations to SHIP 2.0 on behalf of tenants. Updating all referenced links in our documentation.